### PR TITLE
OpenBSD: Wait on kernel relink before syspatch

### DIFF
--- a/openbsd/scripts/postinstall.sh
+++ b/openbsd/scripts/postinstall.sh
@@ -20,6 +20,10 @@ printf "%s\n" "$hostname" > /etc/myname
 printf "127.0.0.1\tlocalhost %s\n" "$hostname" > /etc/hosts
 printf "::1\t\tlocalhost %s\n" "$hostname" >> /etc/hosts
 
+# wait until relink kernel is done, as it blocks syspatch
+echo "Waiting on kernel relink"
+while $(pgrep -qxf '/bin/ksh .*reorder_kernel'); do sleep 1; done
+
 # list and install available patches
 syspatch -c
 # handle: "syspatch: updated itself, run it again to install missing patches"


### PR DESCRIPTION
Without this syspatch would sometimes fail. Relink check is taken from OpenBSD syspatch tool:

https://cvsweb.openbsd.org/cgi-bin/cvsweb/src/usr.sbin/syspatch/syspatch.sh.diff?r1=1.133&r2=1.134